### PR TITLE
Parse data response using readr

### DIFF
--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -99,7 +99,6 @@ retrieve_data <- function(
 
 	data <- readr::read_delim(sstr[[1]][7], skip = 1, col_names = header, 
                               delim = ';')
-	colnames(data) <- header
 
 	return(data)
 	}

--- a/R/retrieve_data.R
+++ b/R/retrieve_data.R
@@ -1,6 +1,8 @@
 #' Retrieves Data from GENESIS Databases 
 #'
 #' \code{retrieve_data} retrieves a single data table.  
+#' 
+#' @import readr
 #'
 #' @param tablename name of the table to retrieve.
 #' @param startyear only retrieve values for years equal or larger to \code{startyear}. Default: 1990.
@@ -95,7 +97,8 @@ retrieve_data <- function(
 
 	header <- c(DQERH, DQA, DQZ, DQIcom)
 
-	data <- readstr_csv(sstr[[1]][7], skip=1)
+	data <- readr::read_delim(sstr[[1]][7], skip = 1, col_names = header, 
+                              delim = ';')
 	colnames(data) <- header
 
 	return(data)

--- a/man/retrieve_data.Rd
+++ b/man/retrieve_data.Rd
@@ -4,8 +4,8 @@
 \alias{retrieve_data}
 \title{Retrieves Data from GENESIS Databases}
 \usage{
-retrieve_data(tablename, startyear = 1900, endyear = 2016, genesis = NULL,
-  ...)
+retrieve_data(tablename, startyear = 1900, endyear = 2016,
+  regionalschluessel = "", genesis = NULL, ...)
 }
 \arguments{
 \item{tablename}{name of the table to retrieve.}
@@ -13,6 +13,8 @@ retrieve_data(tablename, startyear = 1900, endyear = 2016, genesis = NULL,
 \item{startyear}{only retrieve values for years equal or larger to \code{startyear}. Default: 1990.}
 
 \item{endyear}{only retrieve values for years smaller or equal to \code{endyear}. Default: 2016.}
+
+\item{regionalschluessel}{only retrieve values for a particular regional unit. Default: "" (all).}
 
 \item{genesis}{to authenticate a user and set the database (see below).}
 


### PR DESCRIPTION
Fixes a bug where character column with leading zeros is converted to numeric by `read.csv2`, which causes the leading zero to be dropped.

Example: Table `14111KJ002` Flensburg should be `01001`, is `1001`