### PR TITLE
add genesis_url function

### DIFF
--- a/R/helper.R
+++ b/R/helper.R
@@ -71,10 +71,10 @@ get_character_vec <- function(x){
 	return(x)
 	}
 
-genesis_url <- function(tabelle) {
+genesis_url <- function(tablename) {
   return(
     paste0("https://www-genesis.destatis.de/genesis/online?sequenz=tabelleDownload&selectionname=",
-           tabelle,
+           tablename,
            "&format=csv")
   )
 }

--- a/R/helper.R
+++ b/R/helper.R
@@ -66,6 +66,14 @@ to_plain <- function(s) {
 get_character_vec <- function(x){ 
 	x <- paste(unlist(na.omit(x), use.names=FALSE), collapse="_")
 	x <- to_plain(x)
+	
+genesis_url <- function(tabelle) {
+  return(
+    paste0("https://www-genesis.destatis.de/genesis/online?sequenz=tabelleDownload&selectionname=",
+           tabelle,
+           "&format=csv")
+  )
+}
 	x <- str_replace_all(x, " *", "")
 	x <- str_replace_all(x, "[^a-zA-Z0-9_]", "")
 	return(x)

--- a/R/helper.R
+++ b/R/helper.R
@@ -66,7 +66,11 @@ to_plain <- function(s) {
 get_character_vec <- function(x){ 
 	x <- paste(unlist(na.omit(x), use.names=FALSE), collapse="_")
 	x <- to_plain(x)
-	
+	x <- str_replace_all(x, " *", "")
+	x <- str_replace_all(x, "[^a-zA-Z0-9_]", "")
+	return(x)
+	}
+
 genesis_url <- function(tabelle) {
   return(
     paste0("https://www-genesis.destatis.de/genesis/online?sequenz=tabelleDownload&selectionname=",
@@ -74,7 +78,3 @@ genesis_url <- function(tabelle) {
            "&format=csv")
   )
 }
-	x <- str_replace_all(x, " *", "")
-	x <- str_replace_all(x, "[^a-zA-Z0-9_]", "")
-	return(x)
-	}

--- a/R/read_header_genesis.R
+++ b/R/read_header_genesis.R
@@ -35,9 +35,14 @@
 #' 
 #' 
 #' @export
-read_header_genesis <- function(..., start, lines=2, readr_locale=locale(encoding="windows-1252"), replacer=NULL){
+read_header_genesis <- function(..., start, lines=2, readr_locale=locale(encoding="windows-1252"), replacer=NULL, 
+				clean_letters=T){
 	h <- read_csv2(..., col_names=FALSE, skip=start-1, n_max=lines, col_types=cols( .default = col_character() ), locale=readr_locale )
-	h <- apply(h, 2, function(x) get_character_vec(x) )
+	if(clean_letters==T){
+		h <- apply(h, 2, function(x) get_character_vec(x) )
+		} else{
+		h <- apply(h, 2, function(x) paste(unlist(na.omit(x), use.names=FALSE), collapse=" "))
+		}
 	if( !is.null(replacer) ) h[1:length(replacer)] <- replacer
 	return(h)
 	}

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Using the retrieve_datalist() function we download a dataframe of all data table
 
 	genesis <- c(user="ABCDEF", password="XXXXX", db="regio") 
 
-The genesis functions allows currently to access four databases: 
+The genesis function allows currently to access four databases: 
 - `db="regio"` for data from [regionalstatistik.de](https://www.regionalstatistik.de/genesis/online),    
 - `db="nrw"` for data from [landesdatenbank.nrw.de](https://www.landesdatenbank.nrw.de),
 - `db="bm"` for data from [bildungsmonitoring.de](https://www.bildungsmonitoring.de/bildung/online/logon), 
-- `db="de"` for data from [genesis.destatis.de](https://www-genesis.destatis.de/genesis/online)
+- `db="de"` for data from [genesis.destatis.de](https://www-genesis.destatis.de/genesis/online) 
 
-	d <- retrieve_datalist(tableseries="14111", genesis=genesis)
+To retrieve a list of all available data use `retrieve_datalist(tableseries="*", genesis=genesis)`: 
 
-To retrieve a list of all available data use retrieve_datalist(tableseries="*", genesis=genesis). 
+	d <- retrieve_datalist(tableseries="14111", genesis=genesis) 
 
 We then use the str_detect function to filter all data tables that contain the word "Kreise" (county)
 in their name. 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The meta data can be obtained via:
 The `wiesbaden` package also helps to import `csv` tables exported from the GENESIS via their web interfaces and construct valid column names. 
 
 	require(readr)
-	url <- 'https://www-genesis.destatis.de/genesis/online?sequenz=tabelleDownload&selectionname=12411-0004&format=csv'
+	url <- genesis_url(tablename="12411-0004.csv")
 	download.file(url, '12411-0004.csv')
 
 	d <- read_header_genesis('12411-0004.csv', start=6, replacer=c("STAG"))

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `wiesbaden` package also helps to import `csv` tables exported from the GENE
 	url <- genesis_url(tablename="12411-0004.csv")
 	download.file(url, '12411-0004.csv')
 
-	d <- read_header_genesis('12411-0004.csv', start=6, replacer=c("STAG"))
+	d <- read_header_genesis('12411-0004.csv', start=6, replacer=c("STAG"), clean_letters = F)
 	data <- read_csv2('12411-0004.csv', skip=6, n_max=30-6+1, na="-")
 	colnames(data) <- d
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Using the retrieve_datalist() function we download a dataframe of all data table
 	library(dplyr)
 	library(stringr)
 
-	genesis <- c(user="ABCDEF", password="XXXXX", db="regio")
+	genesis <- c(user="ABCDEF", password="XXXXX", db="regio") 
+
+The genesis functions allows currently to access four databases: 
+- `db="regio"` for data from [regionalstatistik.de](https://www.regionalstatistik.de/genesis/online),    
+- `db="nrw"` for data from [landesdatenbank.nrw.de](https://www.landesdatenbank.nrw.de),
+- `db="bm"` for data from [bildungsmonitoring.de](https://www.bildungsmonitoring.de/bildung/online/logon), 
+- `db="de"` for data from [genesis.destatis.de](https://www-genesis.destatis.de/genesis/online)
 
 	d <- retrieve_datalist(tableseries="14111", genesis=genesis)
 
@@ -40,6 +46,7 @@ The meta data can be obtained via:
 
 	metadata <- retrieve_metadata(tablename="14111KJ002", genesis=genesis)
 
+# 
 
 # Read DESTATIS files 
 


### PR DESCRIPTION
I've added a `genesis_url` function for smoother retrieval of files using `download.file`.

I've also added a small explanation to the README file: explaining what the different database abbreviations ("regio", "bm", "de") stand for. This information was somewhat hidden in one of the documentation files.